### PR TITLE
Force line endings to remain LF for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7362,9 +7362,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.3",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,9 @@
     "react-router-dom": "^6.23.1",
     "axios": "^1.7.4"
   },
+  "overrides": {
+    "micromatch": "4.0.8"
+  },
   "devDependencies": {
     "@eslint/js": "^9.3.0",
     "@testing-library/jest-dom": "^5.17.0",


### PR DESCRIPTION
This addresses an issue where pulling the code with git autocrlf enabled on a windows system would replace LF line endings in the `start-nginx.sh` with CRLF. 

This would cause the docker client container to restart with errors as it requires LF line endings to work.